### PR TITLE
Add Forgefriends to the list

### DIFF
--- a/static/CollectiveGovernanceDirectoryData.json
+++ b/static/CollectiveGovernanceDirectoryData.json
@@ -295,6 +295,33 @@
       "language": "DE",
       "numberOfCharacters": 14900,
       "lastChecked": "2023-11-12"
+    },
+    {
+      "organizationName": "ForgeFriends",
+      "organizationURL": "https://forgefriends.org",
+      "artefactTitle": "Community manifesto",
+      "artefactURL": "https://forum.forgefriends.org/t/511",
+      "language": "EN",
+      "numberOfCharacters": 1310,
+      "lastChecked": "2023-12-03"
+    },
+    {
+      "organizationName": "ForgeFriends",
+      "organizationURL": "https://forgefriends.org",
+      "artefactTitle": "Code of Conduct",
+      "artefactURL": "https://forgefriends.org/blog/2021/01/10/code-of-conduct/",
+      "language": "EN",
+      "numberOfCharacters": 4141,
+      "lastChecked": "2023-12-03"
+    },
+    {
+      "organizationName": "ForgeFriends",
+      "organizationURL": "https://forgefriends.org",
+      "artefactTitle": "A guide to forgefriends governance",
+      "artefactURL": "https://forum.forgefriends.org/t/511",
+      "language": "EN",
+      "numberOfCharacters": 6608,
+      "lastChecked": "2023-12-03"
     }
   ]
 }


### PR DESCRIPTION
A PR contains:
- Forgefriends Manifesto, 
- Forgefriends Code of Conduct,
- an article that summarises how the rules described in the above are being interpreted and used in practice in the community.

I assumed this is an append-at-the-end list, I didn't discover any other ordering.

I used character count on the content of the documents with no titles or comments or any other page content where they are displayed, except link counts in the blog post.

I used character count without whitespaces, with them is it respectively: 1565, 4882, 7944.

I feel like CoC and the article are most worth reading, but I would include all three if possible (definitely WITH the article).